### PR TITLE
feat(turn_restrictions): added support for Openstreetmap multiple via-way restrictions

### DIFF
--- a/pkg/http/usecases/routing.go
+++ b/pkg/http/usecases/routing.go
@@ -188,3 +188,11 @@ func (rs *RoutingService) AppendPhantomNodesToPath(path *da.Coordinates, sp, tp 
 func (rs *RoutingService) GetRoutingEngine() *routing.CRPRoutingEngine {
 	return rs.engine.(*routing.CRPRoutingEngine)
 }
+
+func (rs *RoutingService) Snap(ctx context.Context, qOrigLat, qOrigLon, qDstLat, qDstLon float64) (da.PhantomNode, da.PhantomNode) {
+	if util.IsTimeout(ctx) { // https://engineering.grab.com/context-deadlines-and-how-to-set-them
+		return da.NewInvalidPhantomNode(), da.NewInvalidPhantomNode()
+	}
+
+	return rs.SnapOrigDestQueryToNearbyRoadSegments(qOrigLat, qOrigLon, qDstLat, qDstLon)
+}

--- a/pkg/osmparser/graph_builder.go
+++ b/pkg/osmparser/graph_builder.go
@@ -12,7 +12,7 @@ import (
 // roadNetwork = flag if the graph is a road network graph.
 // test shortestpath ada beberapa yang gak pakai road network graph, diambil dari test cases soal-soal kontes pemrograman.
 // jika roadNetwork=false, kita harus tambahkan dummy edge (v,v) untuk setiap vertex v di graph.
-// hal ini karena Customizable Route Planning (CRP) Query phase (support turn costs) mengasumsikan setiap vertices memiliki setidaknya satu edge.
+// karena Customizable Route Planning (CRP) Query phase (support turn costs) mengasumsikan setiap vertices memiliki setidaknya satu edge.
 func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorage, numV uint32, roadNetwork bool) (*da.Graph, [][]da.Index) {
 	var (
 		outEdges    [][]da.OutEdge = make([][]da.OutEdge, numV)
@@ -81,8 +81,8 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 
 	newEInfoId := len(scannedEdges)
 
+	// tambahin parallel edges dulu buat via-way turn restrictions
 	for wayId, way := range p.ways {
-
 		fromRestrictions := p.restrictions[wayId]
 		for fromResId, restriction := range fromRestrictions {
 			if restriction.isWay {
@@ -178,80 +178,88 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 									inspired by how to handle polyvalent turn dari paper CRP dan https://github.com/Project-OSRM/osrm-backend/issues/2681
 				*/ //  nolint: gofmt
 
-				viaWay := restriction.viaWay
-				viaWayNodes := p.ways[viaWay].graphNodes
-
-				viaWayNodesSet := make(map[da.Index]struct{}, len(viaWayNodes))
-				for i := 0; i < len(viaWayNodes); i++ {
-					viaWayNodesSet[viaWayNodes[i]] = struct{}{}
-				}
-
 				fromNodes := way.graphNodes
-				toNodes := p.ways[restriction.to].graphNodes
+				viaWays := restriction.viaWays // bisa aja via-way turn restriction, via-way nya ada lebih dari 1: https://www.openstreetmap.org/relation/17842412
+				for q, viaWay := range viaWays {
+					var toNodes []da.Index
 
-				tail := da.Index(math.MaxUint32)
-				head := da.Index(math.MaxUint32)
-
-				for i := 0; i < len(fromNodes); i++ {
-					if _, ok := viaWayNodesSet[fromNodes[i]]; ok {
-						tail = fromNodes[i]
-						break
+					if q == len(viaWays)-1 {
+						toNodes = p.ways[restriction.to].graphNodes
+					} else {
+						toNodes = p.ways[viaWays[q+1]].graphNodes
 					}
-				}
 
-				for i := 0; i < len(toNodes); i++ {
-					if _, ok := viaWayNodesSet[toNodes[i]]; ok {
-						head = toNodes[i]
-						break
+					viaWayNodes := p.ways[viaWay].graphNodes
+					viaWayNodesSet := make(map[da.Index]struct{}, len(viaWayNodes))
+					for i := 0; i < len(viaWayNodes); i++ {
+						viaWayNodesSet[viaWayNodes[i]] = struct{}{}
 					}
-				}
 
-				if tail == da.Index(math.MaxUint32) || head == math.MaxUint32 {
-					continue
-				}
+					tail := da.Index(math.MaxUint32)
+					head := da.Index(math.MaxUint32)
 
-				viaWayEdge := da.NewEmptyOutEdge()
-
-				viaWayEInfoId := da.Index(da.INVALID_EDGE_ID)
-				for tailExitPoint, outEdge := range outEdges[tail] {
-					eInfoId := edgeInfoIds[tail][tailExitPoint]
-					eHead := outEdge.GetHead()
-					if graphStorage.GetOsmWayId(eInfoId) == uint64(viaWay) && eHead == head {
-						viaWayEInfoId = eInfoId
-						viaWayEdge = outEdge
-						break
+					for i := 0; i < len(fromNodes); i++ {
+						if _, ok := viaWayNodesSet[fromNodes[i]]; ok {
+							tail = fromNodes[i]
+							break
+						}
 					}
+
+					for i := 0; i < len(toNodes); i++ {
+						if _, ok := viaWayNodesSet[toNodes[i]]; ok {
+							head = toNodes[i]
+							break
+						}
+					}
+
+					if tail == da.Index(math.MaxUint32) || head == math.MaxUint32 {
+						continue
+					}
+
+					viaWayEdge := da.NewEmptyOutEdge()
+
+					viaWayEInfoId := da.Index(da.INVALID_EDGE_ID)
+					for tailExitPoint, outEdge := range outEdges[tail] {
+						eInfoId := edgeInfoIds[tail][tailExitPoint]
+						eHead := outEdge.GetHead()
+						if graphStorage.GetOsmWayId(eInfoId) == uint64(viaWay) && eHead == head {
+							viaWayEInfoId = eInfoId
+							viaWayEdge = outEdge
+							break
+						}
+					}
+
+					if viaWayEInfoId == da.INVALID_EDGE_ID {
+						continue
+					}
+
+					viaHead := viaWayEdge.GetHead()
+					viaHeadNewEdgeEntryPoint := da.Index(len(inEdges[viaHead]))
+					viaParallelOutEdge := da.NewOutEdge(da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId)*da.Index(q), viaHead,
+						viaWayEdge.GetWeight(), viaWayEdge.GetLength(), viaHeadNewEdgeEntryPoint, viaWayEdge.GetHighwayType())
+					viaParallelOutEdge.SetParallelEdge()
+					outEdges[tail] = append(outEdges[tail], viaParallelOutEdge)
+					edgeInfoIds[tail] = append(edgeInfoIds[tail], da.Index(newEInfoId))
+					outDegree[tail]++
+
+					tailNewEdgeExitPoint := da.Index(len(outEdges[tail]) - 1)
+					viaParallelInEdge := da.NewInEdge(da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId)*da.Index(q), tail,
+						viaWayEdge.GetWeight(), viaWayEdge.GetLength(), tailNewEdgeExitPoint, viaWayEdge.GetHighwayType())
+					viaParallelInEdge.SetParallelEdge()
+					inEdges[viaHead] = append(inEdges[viaHead], viaParallelInEdge)
+					inDegree[viaHead]++
+					startPointId, endPointId := graphStorage.GetEdgeGeometryEndpoints(viaWayEInfoId)
+					graphStorage.AppendEdgeMetadata(
+						int64(graphStorage.GetOsmWayId(viaWayEInfoId)),
+						startPointId, endPointId,
+						graphStorage.GetStreetNameId(viaWayEInfoId),
+						graphStorage.GetRoadClass(viaWayEInfoId),
+						graphStorage.GetRoadClassLink(viaWayEInfoId),
+						graphStorage.GetRoadLanes(viaWayEInfoId),
+					)
+					newEInfoId++
+					fromNodes = viaWayNodes
 				}
-
-				if viaWayEInfoId == da.INVALID_EDGE_ID {
-					continue
-				}
-
-				viaHead := viaWayEdge.GetHead()
-				viaHeadNewEdgeEntryPoint := da.Index(len(inEdges[viaHead]))
-				viaParallelOutEdge := da.NewOutEdge(da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId), viaHead,
-					viaWayEdge.GetWeight(), viaWayEdge.GetLength(), viaHeadNewEdgeEntryPoint, viaWayEdge.GetHighwayType())
-				viaParallelOutEdge.SetParallelEdge()
-				outEdges[tail] = append(outEdges[tail], viaParallelOutEdge)
-				edgeInfoIds[tail] = append(edgeInfoIds[tail], da.Index(newEInfoId))
-				outDegree[tail]++
-
-				tailNewEdgeExitPoint := da.Index(len(outEdges[tail]) - 1)
-				viaParallelInEdge := da.NewInEdge(da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId), tail,
-					viaWayEdge.GetWeight(), viaWayEdge.GetLength(), tailNewEdgeExitPoint, viaWayEdge.GetHighwayType())
-				viaParallelInEdge.SetParallelEdge()
-				inEdges[viaHead] = append(inEdges[viaHead], viaParallelInEdge)
-				inDegree[viaHead]++
-				startPointId, endPointId := graphStorage.GetEdgeGeometryEndpoints(viaWayEInfoId)
-				graphStorage.AppendEdgeMetadata(
-					int64(graphStorage.GetOsmWayId(viaWayEInfoId)),
-					startPointId, endPointId,
-					graphStorage.GetStreetNameId(viaWayEInfoId),
-					graphStorage.GetRoadClass(viaWayEInfoId),
-					graphStorage.GetRoadClassLink(viaWayEInfoId),
-					graphStorage.GetRoadLanes(viaWayEInfoId),
-				)
-				newEInfoId++
 			}
 		}
 	}
@@ -320,6 +328,16 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 				}
 			}
 		}
+	}
+
+	isParallelEdge := func(eId, fromResId, q da.Index) bool {
+		if eId < da.INVALID_PARALLEL_EDGE_ID {
+			return false
+		}
+		if eId == da.INVALID_PARALLEL_EDGE_ID+fromResId*q {
+			return true
+		}
+		return false
 	}
 
 	// let m=number of ways , q = max number of nodes of any osm ways, r = max number of restrictions of any osm ways
@@ -663,6 +681,7 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 								turnMatrices[via][rowOffset+exitPoint] = pkg.NO_ENTRY
 
 							case NO_RIGHT_TURN: // contoh: https://www.openstreetmap.org/relation/5710505
+
 								turnMatrices[via][rowOffset+exitPoint] = pkg.NO_ENTRY
 
 							case NO_STRAIGHT_ON:
@@ -771,194 +790,227 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 
 				*/ //  nolint: gofmt
 
-				viaWay := restriction.viaWay
-				viaWayNodes := p.ways[viaWay].graphNodes
+				// bisa aja via-way turn restriction, via-way nya ada lebih dari 1: https://www.openstreetmap.org/relation/17842412
 
-				viaWayNodesSet := make(map[da.Index]struct{}, len(viaWayNodes))
-				for i := 0; i < len(viaWayNodes); i++ {
-					viaWayNodesSet[viaWayNodes[i]] = struct{}{}
-				}
+				viaWays := restriction.viaWays
+				moreThanOneViaWays := len(viaWays) > 1
+				for q, viaWay := range viaWays {
 
-				fromNodes := way.graphNodes
-				toNodes := p.ways[restriction.to].graphNodes
+					var (
+						toNodes                   []da.Index
+						lastViaway                bool
+						tailInEdgeInParallelEdges bool
+					)
+					if q == len(viaWays)-1 {
+						toNodes = p.ways[restriction.to].graphNodes
+						lastViaway = true
 
-				tail := da.Index(math.MaxUint32) // tail dari via-edge
-				head := da.Index(math.MaxUint32) // head dari via-edge
+						if moreThanOneViaWays {
+							tailInEdgeInParallelEdges = true
+						}
+					} else {
+						toNodes = p.ways[viaWays[q+1]].graphNodes
 
-				for i := 0; i < len(fromNodes); i++ {
-					if _, ok := viaWayNodesSet[fromNodes[i]]; ok {
-						tail = fromNodes[i]
-						break
-					}
-				}
-
-				for i := 0; i < len(toNodes); i++ {
-					if _, ok := viaWayNodesSet[toNodes[i]]; ok {
-						head = toNodes[i]
-						break
-					}
-				}
-				if tail == da.Index(math.MaxUint32) || head == math.MaxUint32 {
-					continue
-				}
-
-				tailNewViaEdgeExitPoint := da.Index(0)
-
-				viaWayEInfoId := da.Index(da.INVALID_EDGE_ID)
-				for i := 0; i < len(outEdges[tail]); i++ {
-					eInfoId := edgeInfoIds[tail][i]
-					outEdge := outEdges[tail][i]
-					if outEdge.GetHighwayType() == pkg.INVALID_HIGHWAY {
-						// skip dummy edges
-						continue
-					}
-					eHead := outEdge.GetHead()
-					if graphStorage.GetOsmWayId(eInfoId) == uint64(viaWay) && eHead == head && outEdge.GetEdgeId() == da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId) {
-						tailNewViaEdgeExitPoint = da.Index(i)
-						viaWayEInfoId = eInfoId
-					}
-				}
-
-				if viaWayEInfoId == da.INVALID_EDGE_ID {
-					continue
-				}
-
-				headNewViaEdgeEntryPoint := da.Index(math.MaxUint32)
-				for i := 0; i < len(inEdges[head]); i++ {
-					inEdge := inEdges[head][i]
-					eTail := inEdge.GetTail()
-					if eTail == tail && inEdge.GetEdgeId() == da.INVALID_PARALLEL_EDGE_ID+da.Index(fromResId) {
-						headNewViaEdgeEntryPoint = da.Index(i)
-					}
-				}
-
-				if headNewViaEdgeEntryPoint == math.MaxUint32 {
-					continue
-				}
-
-				for i := 0; i < len(fromNodes); i++ {
-					if fromNodes[i] == tail {
-						if i == 0 && way.oneWay {
-							// no predecessor
-							continue
+						if q > 0 {
+							tailInEdgeInParallelEdges = true
 						}
 
-						var predecessor da.Index // predecessor dari tail dari edge via nya turn restriction
-						if i == 0 {
-							// note that di osm_parser.go , way bisa two-way (dua arah) yang mana setiap pasang junction/end node dari osm way kita pecah jadi dua edges (kalau two-way)...
-							// kalau via node dari turn restriction di first node dari from-way..
-							// berarti predecessor nya ada di next node (i+1).. ke arah forward..
-							// from-way nodes: via<->u2<->u3<->-.....<->un
-							predecessor = fromNodes[i+1]
-						} else {
-							predecessor = fromNodes[i-1]
-						}
+					}
 
-						if predecessor == head {
-							continue
-						}
+					viaWayNodes := p.ways[viaWay].graphNodes
 
-						successor := da.Index(math.MaxUint32) // successor dari head dari edge via nya turn restriction
+					viaWayNodesSet := make(map[da.Index]struct{}, len(viaWayNodes))
+					for i := 0; i < len(viaWayNodes); i++ {
+						viaWayNodesSet[viaWayNodes[i]] = struct{}{}
+					}
 
-						for j := 0; j < len(toNodes); j++ {
-							if toNodes[j] == head {
-								if j == len(toNodes)-1 {
-									// note that di osm_parser.go , way bisa two-way (dua arah) yang mana setiap pasang junction/end node dari osm way kita pecah jadi dua edges (kalau two-way)...
-									// kalau via node dari turn restriction di last node dari to-way..
-									// berarti predecessor nya ada di next node (i-1).. ke arah backward
-									// to-way nodes: u1<->u2<->u3<->-.....<->via
+					tail := da.Index(math.MaxUint32) // tail dari via-edge
+					head := da.Index(math.MaxUint32) // head dari via-edge
 
-									successor = toNodes[j-1]
-								} else {
-									successor = toNodes[j+1]
-								}
-								break
-							}
-						}
-
-						if successor != da.Index(math.MaxUint32) && successor != restriction.via {
-
-							tailEntryPoint := da.Index(math.MaxUint32)
-
-							for k := da.Index(0); k < da.Index(len(inEdges[tail])); k++ {
-								if inEdges[tail][k].GetTail() == predecessor {
-									tailEntryPoint = k
-								} else {
-									// kasih turn cost INF buat transisi dari  all other inEdges dari tail (selain from-edge) -> tail -> via-edge 2
-									turnMatrices[tail][k*da.Index(outDegree[tail])+tailNewViaEdgeExitPoint] = pkg.NO_ENTRY
-								}
-							}
-
-							if tailEntryPoint == da.Index(math.MaxUint32) {
-								continue
-							}
-
-							tailViaEdgeExitPoint := da.Index(math.MaxUint32)
-
-							for k := 0; k < len(outEdges[tail]); k++ {
-								outEdge := outEdges[tail][k]
-								if outEdge.GetHead() == head && outEdge.GetEdgeId() < da.INVALID_PARALLEL_EDGE_ID {
-									tailViaEdgeExitPoint = da.Index(k)
-									break
-								}
-							}
-
-							if tailViaEdgeExitPoint == da.Index(math.MaxUint32) {
-								continue
-							}
-
-							rowOffset := tailEntryPoint * da.Index(outDegree[tail])
-
-							// kasih turn cost 0 buat transisi dari from-edge -> tail -> via-edge 2
-							turnMatrices[tail][rowOffset+tailNewViaEdgeExitPoint] = pkg.NONE
-
-							// kasih turn cost INF buat transisi dari from-edge -> tail -> via-edge 1
-							turnMatrices[tail][rowOffset+tailViaEdgeExitPoint] = pkg.NO_ENTRY
-
-							// dari via-edge 2 ke to-edge dikasih turn cost INF (karena OSM u-turn restriction diatas).. biar dari  Jalan Siliwangi ke arah timur (from-edge 2) -> via-edge 2 -> to-edge gabisa lewat...
-							// dari via-edge 1 ke to-edge dikasih turn cost 0... biar dari jalan subali raya  -> from-edge 1 -> via-edge 1 -> to-edge bisa lewat ...
-
-							headExitPoint := da.Index(math.MaxUint32)
-							for k := 0; k < len(outEdges[head]); k++ {
-								outEdge := outEdges[head][k]
-								if outEdge.GetHead() == successor {
-									headExitPoint = da.Index(k)
-
-									break
-								}
-							}
-
-							if headExitPoint == da.Index(math.MaxUint32) {
-								continue
-							}
-
-							rowOffset = headNewViaEdgeEntryPoint * da.Index(outDegree[head])
-
-							switch restriction.turnRestriction {
-							case NO_LEFT_TURN:
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
-
-							case NO_RIGHT_TURN: // contoh: https://www.openstreetmap.org/relation/5710505
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
-
-							case NO_STRAIGHT_ON:
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
-
-							case NO_U_TURN: // harus NO_ENTRY karena gak boleh u-turn: example: https://www.openstreetmap.org/relation/10732316#map=19/-7.566370/110.775455
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
-
-							case NO_ENTRY:
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
-
-							default:
-								turnMatrices[head][rowOffset+headExitPoint] = pkg.NONE
-
-							}
-
+					for i := 0; i < len(fromNodes); i++ {
+						if _, ok := viaWayNodesSet[fromNodes[i]]; ok {
+							tail = fromNodes[i]
 							break
 						}
 					}
 
+					for i := 0; i < len(toNodes); i++ {
+						if _, ok := viaWayNodesSet[toNodes[i]]; ok {
+							head = toNodes[i]
+							break
+						}
+					}
+					if tail == da.Index(math.MaxUint32) || head == math.MaxUint32 {
+						continue
+					}
+
+					tailNewViaEdgeExitPoint := da.Index(0)
+
+					viaWayEInfoId := da.Index(da.INVALID_EDGE_ID)
+					for i := 0; i < len(outEdges[tail]); i++ {
+						eInfoId := edgeInfoIds[tail][i]
+						outEdge := outEdges[tail][i]
+						if outEdge.GetHighwayType() == pkg.INVALID_HIGHWAY {
+							// skip dummy edges
+							continue
+						}
+						eHead := outEdge.GetHead()
+						if graphStorage.GetOsmWayId(eInfoId) == uint64(viaWay) && eHead == head &&
+							isParallelEdge(outEdge.GetEdgeId(), da.Index(fromResId), da.Index(q)) {
+							tailNewViaEdgeExitPoint = da.Index(i)
+							viaWayEInfoId = eInfoId
+						}
+					}
+
+					if viaWayEInfoId == da.INVALID_EDGE_ID {
+						continue
+					}
+
+					headNewViaEdgeEntryPoint := da.Index(math.MaxUint32)
+					for i := 0; i < len(inEdges[head]); i++ {
+						inEdge := inEdges[head][i]
+						eTail := inEdge.GetTail()
+						if eTail == tail && isParallelEdge(inEdge.GetEdgeId(), da.Index(fromResId), da.Index(q)) {
+							headNewViaEdgeEntryPoint = da.Index(i)
+						}
+					}
+
+					if headNewViaEdgeEntryPoint == math.MaxUint32 {
+						continue
+					}
+
+					for i := 0; i < len(fromNodes); i++ {
+						if fromNodes[i] == tail {
+							if i == 0 && way.oneWay {
+								// no predecessor
+								continue
+							}
+
+							var predecessor da.Index // predecessor dari tail dari edge via nya turn restriction
+							if i == 0 {
+								// note that di osm_parser.go , way bisa two-way (dua arah) yang mana setiap pasang junction/end node dari osm way kita pecah jadi dua edges (kalau two-way)...
+								// kalau via node dari turn restriction di first node dari from-way..
+								// berarti predecessor nya ada di next node (i+1).. ke arah forward..
+								// from-way nodes: via<->u2<->u3<->-.....<->un
+								predecessor = fromNodes[i+1]
+							} else {
+								predecessor = fromNodes[i-1]
+							}
+
+							if predecessor == head {
+								continue
+							}
+
+							successor := da.Index(math.MaxUint32) // successor dari head dari edge via nya turn restriction
+
+							for j := 0; j < len(toNodes); j++ {
+								if toNodes[j] == head {
+									if j == len(toNodes)-1 {
+										// note that di osm_parser.go , way bisa two-way (dua arah) yang mana setiap pasang junction/end node dari osm way kita pecah jadi dua edges (kalau two-way)...
+										// kalau via node dari turn restriction di last node dari to-way..
+										// berarti predecessor nya ada di next node (i-1).. ke arah backward
+										// to-way nodes: u1<->u2<->u3<->-.....<->via
+
+										successor = toNodes[j-1]
+									} else {
+										successor = toNodes[j+1]
+									}
+									break
+								}
+							}
+
+							if successor != da.Index(math.MaxUint32) {
+
+								tailEntryPoint := da.Index(math.MaxUint32)
+
+								for k := da.Index(0); k < da.Index(len(inEdges[tail])); k++ {
+									tailInEdge := inEdges[tail][k]
+									validInEdge := ((tailInEdgeInParallelEdges && isParallelEdge(tailInEdge.GetEdgeId(), da.Index(fromResId), da.Index(q-1))) ||
+										!tailInEdgeInParallelEdges && !isParallelEdge(tailInEdge.GetEdgeId(), da.Index(fromResId), da.Index(q-1)))
+									if tailInEdge.GetTail() == predecessor && validInEdge {
+										tailEntryPoint = k
+									} else {
+										// kasih turn cost INF buat transisi dari  all other inEdges dari tail (selain from-edge) -> tail -> via-edge 2
+										turnMatrices[tail][k*da.Index(outDegree[tail])+tailNewViaEdgeExitPoint] = pkg.NO_ENTRY
+									}
+								}
+
+								if tailEntryPoint == da.Index(math.MaxUint32) {
+									continue
+								}
+
+								tailViaEdgeExitPoint := da.Index(math.MaxUint32)
+
+								for k := 0; k < len(outEdges[tail]); k++ {
+									outEdge := outEdges[tail][k]
+									validOutEdge := !isParallelEdge(outEdge.GetEdgeId(), da.Index(fromResId), da.Index(q))
+									if outEdge.GetHead() == head && validOutEdge {
+										tailViaEdgeExitPoint = da.Index(k)
+										break
+									}
+								}
+
+								if tailViaEdgeExitPoint == da.Index(math.MaxUint32) {
+									continue
+								}
+
+								rowOffset := tailEntryPoint * da.Index(outDegree[tail])
+
+								// kasih turn cost 0 buat transisi dari from-edge -> tail -> via-edge 2
+								turnMatrices[tail][rowOffset+tailNewViaEdgeExitPoint] = pkg.NONE
+
+								// kasih turn cost INF buat transisi dari from-edge -> tail -> via-edge 1
+								turnMatrices[tail][rowOffset+tailViaEdgeExitPoint] = pkg.NO_ENTRY
+
+								if lastViaway {
+
+									// dari via-edge 2 ke to-edge dikasih turn cost INF (karena OSM u-turn restriction diatas).. biar dari  Jalan Siliwangi ke arah timur (from-edge 2) -> via-edge 2 -> to-edge gabisa lewat...
+									// dari via-edge 1 ke to-edge dikasih turn cost 0... biar dari jalan subali raya  -> from-edge 1 -> via-edge 1 -> to-edge bisa lewat ...
+
+									headExitPoint := da.Index(math.MaxUint32)
+									for k := 0; k < len(outEdges[head]); k++ {
+										outEdge := outEdges[head][k]
+										if outEdge.GetHead() == successor && !isParallelEdge(outEdge.GetEdgeId(), da.Index(fromResId), da.Index(q)) {
+											headExitPoint = da.Index(k)
+
+											break
+										}
+									}
+
+									if headExitPoint == da.Index(math.MaxUint32) {
+										continue
+									}
+
+									rowOffset = headNewViaEdgeEntryPoint * da.Index(outDegree[head])
+
+									switch restriction.turnRestriction {
+									case NO_LEFT_TURN:
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
+
+									case NO_RIGHT_TURN: // contoh: https://www.openstreetmap.org/relation/5710505
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
+
+									case NO_STRAIGHT_ON:
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
+
+									case NO_U_TURN: // harus NO_ENTRY karena gak boleh u-turn: example: https://www.openstreetmap.org/relation/10732316#map=19/-7.566370/110.775455
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
+
+									case NO_ENTRY:
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NO_ENTRY
+
+									default:
+										turnMatrices[head][rowOffset+headExitPoint] = pkg.NONE
+
+									}
+								}
+
+								break
+							}
+						}
+					}
+
+					fromNodes = viaWayNodes
 				}
 			}
 		}
@@ -968,6 +1020,7 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 	matrixOffset := 0
 
 	for v := 0; v < len(vertices)-1; v++ {
+
 		// set the turnTablePtr of vertex v to the current matrixOffset
 		// matrix offset is index of the first element of turnMatrices[v] in the flattened matrices array
 		vertices[v].SetTurnTablePtr(da.Index(matrixOffset))
@@ -989,7 +1042,7 @@ func (p *OsmParser) BuildGraph(scannedEdges []Edge, graphStorage *da.GraphStorag
 		inEdgeOffset += da.Index(len(inEdges[i]))
 	}
 
-	// dummy update vertex
+	// dummy vertex
 	vertices[len(vertices)-1] = da.NewVertex(0, 0, da.Index(len(vertices)-1))
 	vertices[len(vertices)-1].SetFirstOut(outEdgeOffset)
 	vertices[len(vertices)-1].SetFirstIn(inEdgeOffset)

--- a/pkg/osmparser/osm_parser.go
+++ b/pkg/osmparser/osm_parser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +38,7 @@ func NewNodeCoord(lat, lon float64) NodeCoord {
 
 type restriction struct {
 	via             da.Index
-	viaWay          int64
+	viaWays         []int64
 	to              int64
 	turnRestriction TurnRestriction
 	isWay           bool
@@ -142,6 +143,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 
 	restrictions := make(map[int64][]struct {
 		via             int64
+		viaWays         []int64
 		turnRestriction TurnRestriction
 		to              int64
 		isWay           bool
@@ -181,7 +183,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 						}
 					} else {
 						// ini junction node dari osm way
-						// jadi ada setidaknya 2 way yang punya node yang sama
+						// jadi ada setidaknya 2 osm way yang punya node yang sama
 						// nah node yang sama ini ditandain JUNCTION_NODE
 						p.wayNodeMap[int64(node.ID)] = nodeWithCoord{JUNCTION_NODE, NewNodeCoord(node.Lat, node.Lon)}
 					}
@@ -210,17 +212,13 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 					// https://wiki.openstreetmap.org/wiki/Relation:restriction
 
 					from := int64(0)
-					via := int64(0)
+					via := int64(math.MaxInt64)
 					to := int64(0)
 					// https://www.openstreetmap.org/api/0.6/relation/5710500
 					// example: https://www.openstreetmap.org/relation/10732316#map=19/-7.566370/110.775455  or https://www.openstreetmap.org/api/0.6/relation/10732316
 
-					if len(relation.Members) > 3 {
-						// sementara gak support restrictions yang via nya lebih dari 1.
-						// example: https://www.openstreetmap.org/relation/4763182#map=19/-7.783071/110.360767
-						// masih gak tau cara incorporate di routing algorithm nya gmn
-						continue
-					}
+					viaways := make([]int64, 0)
+					// turn restriction dengan via-way bisa aja via-way nya lebih dari 1, example:  example: https://www.openstreetmap.org/relation/4763182#map=19/-7.783071/110.360767
 
 					isWay := false
 					for _, member := range relation.Members {
@@ -233,11 +231,12 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 							isWay = false
 						} else if member.Type == "way" && member.Role == "via" {
 							// example: https://www.openstreetmap.org/relation/13427535
-							via = member.Ref
+							viaways = append(viaways, member.Ref)
 							isWay = true
 						}
 					}
-					if via == 0 {
+
+					if via == math.MaxInt64 && len(viaways) == 0 {
 						// skip adding restriction yang gak sesuai rule restriction osm:
 						// example: https://www.openstreetmap.org/relation/12868204/history/2 (version 2) gak ada via nya...
 						// padahal di version 1 bener (ada via nya): https://www.openstreetmap.org/relation/12868204/history/1
@@ -247,6 +246,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 
 					rest := struct {
 						via             int64
+						viaWays         []int64
 						turnRestriction TurnRestriction
 						to              int64
 						isWay           bool
@@ -255,6 +255,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 						to:              to,
 						turnRestriction: parseTurnRestriction(tagVal),
 						isWay:           isWay,
+						viaWays:         viaways,
 					}
 					restrictions[from] = append(restrictions[from], rest)
 				}
@@ -403,6 +404,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 	for from, val := range restrictions {
 		savedRest := make([]restriction, len(val))
 		for i := range val {
+
 			if !val[i].isWay {
 				savedRest[i] = restriction{
 					via:             p.nodeIDMap[val[i].via],
@@ -412,7 +414,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 				}
 			} else {
 				savedRest[i] = restriction{
-					viaWay:          val[i].via,
+					viaWays:         val[i].viaWays,
 					to:              val[i].to,
 					turnRestriction: val[i].turnRestriction,
 					isWay:           val[i].isWay,
@@ -420,6 +422,7 @@ func (p *OsmParser) Parse(mapFile string, logger *zap.Logger) (*da.Graph, [][]da
 			}
 
 		}
+
 		p.restrictions[from] = savedRest
 	}
 

--- a/tests/preprocessor/crp_preprocessor_test.go
+++ b/tests/preprocessor/crp_preprocessor_test.go
@@ -1209,8 +1209,12 @@ func TestPreprocessTurnRestrictionsUsingOSMFile(t *testing.T) {
 					headOsmNodeId := graph.GetVertexOsmId(head)
 					if !tc.turnRestriction.isViaway {
 						if headOsmNodeId == uint64(rest.via) {
+						
 							// traverse ke semua outedges of head
 							graph.ForOutEdgesOf(head, fromEntryPoint, func(eIdTo, headTo da.Index, _, _ float64, _, headToEntryPoint da.Index, turnType pkg.TurnType, _ pkg.OsmHighwayType) {
+								if graph.IsDummyOutEdge(eIdTo) {
+									return 
+								}
 								toEdgeWayId := graph.GetOsmWayId(eIdTo)
 								if rest.toWay == toEdgeWayId {
 									// cek turnSign dari:

--- a/tests/query/crp_query_test.go
+++ b/tests/query/crp_query_test.go
@@ -23,6 +23,7 @@ import (
 	da "github.com/lintang-b-s/Navigatorx/pkg/datastructure"
 	"github.com/lintang-b-s/Navigatorx/pkg/engine"
 	"github.com/lintang-b-s/Navigatorx/pkg/engine/routing"
+	"github.com/lintang-b-s/Navigatorx/pkg/http/usecases"
 	"github.com/lintang-b-s/Navigatorx/pkg/landmark"
 	"github.com/lintang-b-s/Navigatorx/pkg/logger"
 	log "github.com/lintang-b-s/Navigatorx/pkg/logger"
@@ -30,7 +31,9 @@ import (
 	"github.com/lintang-b-s/Navigatorx/pkg/partitioner"
 	preprocesser "github.com/lintang-b-s/Navigatorx/pkg/preprocessor"
 	preprocessor "github.com/lintang-b-s/Navigatorx/pkg/preprocessor"
+	"github.com/lintang-b-s/Navigatorx/pkg/spatialindex"
 	"github.com/lintang-b-s/Navigatorx/pkg/util"
+	"go.uber.org/zap"
 )
 
 const (
@@ -333,7 +336,7 @@ func init() {
 	util.InitConfig()
 }
 
-func setup(t *testing.T, turnCost bool) (*engine.Engine, *landmark.Landmark) {
+func setup(t *testing.T, turnCost bool) (*engine.Engine, *landmark.Landmark, *zap.Logger) {
 	if err := os.MkdirAll("./data", 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +435,7 @@ func setup(t *testing.T, turnCost bool) (*engine.Engine, *landmark.Landmark) {
 		t.Fatal(err)
 	}
 
-	return re, lm
+	return re, lm, logger
 }
 
 /*
@@ -443,7 +446,7 @@ untuk plain dijkstra find single source shortest paths (sssp), from s to all oth
 untuk alt query crp find point-to-point(p2p) shortest paths, untuk semua p2p sp queries diatas
 note that Customizable Route Planning (CRP) query/multilevel dijkstra (MLD) [https://github.com/Project-OSRM/osrm-backend]/ multilevel A*, landmarks, and triangle inequality (ALT) hanya mempercepat p2p sp query bukan mempercepat sssp query
 
-stress tests ini selesai dalam 30 detik
+stress tests ini selesai dalam 7 menit
 dan akan berhenti ketika ada counterexample
 cpu: AMD Ryzen 5 7540U w/ Radeon(TM) 740M Graphic #6 cpu cores #12 threads
 ram: 16gb
@@ -453,13 +456,13 @@ karena bakal time out kalau pakai vscode
 */
 
 func TestCRPQueryStressNoTurnCostTest(t *testing.T) {
-	re, _ := setup(t, false)
+	re, _, _ := setup(t, false)
 	g := re.GetRoutingEngine().GetGraph()
 
 	rd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	V := g.NumberOfVertices()
 
-	n := 50
+	n := 20
 	qset := make(map[da.Index]struct{})
 
 	queries := make([]da.Index, 0, n)
@@ -602,8 +605,14 @@ func TestCRPQueryStressNoTurnCostTest(t *testing.T) {
 	})
 }
 
+/*
+
+please run the test using command: "cd tests/query && go test -run TestCRPQueryStressWithTurnCostTest  -v -timeout=0  -count=1"
+karena bakal time out kalau pakai vscode
+*/
+
 func TestCRPQueryStressWithTurnCostTest(t *testing.T) {
-	re, _ := setup(t, true)
+	re, _, _ := setup(t, true)
 	g := re.GetRoutingEngine().GetGraph()
 
 	rd := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -757,4 +766,167 @@ func TestCRPQueryStressWithTurnCostTest(t *testing.T) {
 			}
 		}
 	})
+}
+
+// test ini bertujuan untuk memastikan rute shortest path dan rute alternatif yang direturn routing engine tidak melewati OSM turn restrictions.
+/*
+please run the test using command: "cd tests/query && go test -run TestCRPQueryTurnRestriction  -v -timeout=0  -count=1"
+karena bakal time out kalau pakai vscode
+*/
+func TestCRPQueryTurnRestriction(t *testing.T) {
+	eng, _, logger := setup(t, true)
+	re := eng.GetRoutingEngine()
+	g := re.GetGraph()
+	altSearch := routing.NewAlternativeRouteSearch(re)
+
+	type turnResType struct {
+		restriction string
+		from, to    int64
+		viaWays     []int64
+		viaNode     int64
+		isViaWay    bool
+	}
+	testCases := []struct {
+		name                          string
+		turnRestriction               turnResType
+		queryOrigin, queryDestination da.Coordinate
+	}{
+		{
+			name:             "Simpang Pingit U-turn Restriction https://www.openstreetmap.org/relation/17842412 ,  example correct route:  https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.782881%2C110.361282%3B-7.782681%2C110.361341#map=19/-7.781811/110.361046",
+			queryOrigin:      da.NewCoordinate(-7.782881, 110.361282),
+			queryDestination: da.NewCoordinate(-7.782681, 110.361341),
+			turnRestriction:  turnResType{restriction: "no_u_turn", from: 263612372, isViaWay: true, viaWays: []int64{590074069, 1490467372}, to: 898190693},
+		},
+		{
+			name:             "Simpang Pingit U-turn Restriction 2 https://www.openstreetmap.org/relation/4763182 ,  example correct route: https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.781084%2C110.361035%3B-7.781015%2C110.360724#map=17/-7.784382/110.360112",
+			queryOrigin:      da.NewCoordinate(-7.781084, 110.361035),
+			queryDestination: da.NewCoordinate(-7.781015, 110.360724),
+			turnRestriction:  turnResType{restriction: "no_u_turn", from: 898190692, isViaWay: true, viaWays: []int64{1459769996, 263612372}, to: 590074069},
+		},
+
+		{
+			name:             "Cik di Tiro u-turn restriction https://www.openstreetmap.org/relation/13427535,  example correct route: https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.782253%2C110.374966%3B-7.782219%2C110.375243#map=17/-7.779046/110.375637",
+			queryOrigin:      da.NewCoordinate(-7.782253, 110.374966),
+			queryDestination: da.NewCoordinate(-7.782219, 110.375243),
+			turnRestriction:  turnResType{restriction: "no_u_turn", from: 153821715, isViaWay: true, viaWays: []int64{1001303583}, to: 1001303581},
+		},
+		{
+			name:             "Simpang tugu jogja u-turn restriction https://www.openstreetmap.org/relation/17670402,  example correct route: https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.783003%2C110.369079%3B-7.782729%2C110.367582#map=18/-7.782897/110.367665",
+			queryOrigin:      da.NewCoordinate(-7.783003, 110.369079),
+			queryDestination: da.NewCoordinate(-7.782729, 110.367582),
+			turnRestriction:  turnResType{restriction: "no_u_turn", from: 357658481, isViaWay: true, viaWays: []int64{1110178248}, to: 1108475786},
+		},
+
+		{
+			name:             "Simpang Gramedia no_right_turn restriction https://www.openstreetmap.org/relation/5710502,  example correct route: https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.783686%2C110.374746%3B-7.78296%2C110.377024#map=16/-7.78528/110.37525",
+			queryOrigin:      da.NewCoordinate(-7.783686, 110.374746),
+			queryDestination: da.NewCoordinate(-7.782960, 110.377024),
+			turnRestriction:  turnResType{restriction: "no_right_turn", from: 1347054637, isViaWay: false, viaNode: 271845942, to: 179907371},
+		},
+
+		{
+			name:             "Jalan Seturan Raya no_right_turn restriction https://www.openstreetmap.org/relation/18854138,  example correct route: openstreetmap.org/directions?engine=fossgis_osrm_car&route=-7.764298%2C110.41148%3B-7.761288%2C110.422211#map=19/-7.763936/110.411675",
+			queryOrigin:      da.NewCoordinate(-7.764298, 110.411480),
+			queryDestination: da.NewCoordinate(-7.761288, 110.422211),
+			turnRestriction:  turnResType{restriction: "no_right_turn", from: 1124615933, isViaWay: false, viaNode: 1390908542, to: 586534196},
+		},
+	}
+
+	isSame := func(a []int64, b []int64) bool {
+		if len(a) != len(b) {
+			return false
+		}
+
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// path= list of edgeIds
+	isCorrect := func(path []da.Index, tr turnResType) ([]int64, bool) {
+		restrictedPathLength := 0
+		if tr.isViaWay {
+			restrictedPathLength = len(tr.viaWays) + 2 // len(via-ways) + from + to. example: https://www.openstreetmap.org/relation/17842412
+		} else {
+			restrictedPathLength = 2 // from + to . (via Node ada di head nya from edge)
+		}
+
+		restrictedPath := make([]int64, restrictedPathLength)
+		restrictedPath[0] = tr.from
+		restrictedPath[restrictedPathLength-1] = tr.to
+		if tr.isViaWay {
+			for i := 1; i < restrictedPathLength-1; i++ {
+				restrictedPath[i] = tr.viaWays[i-1]
+			}
+		} else {
+			restrictedPath[1] = tr.viaNode
+		}
+
+		for i := 0; i < len(path)-(restrictedPathLength-1); i++ {
+			subPath := make([]int64, 0, restrictedPathLength)
+
+			if tr.isViaWay {
+				cur := path[i]
+				currOsmWayId := g.GetOsmWayId(cur)
+				subPath = append(subPath, currOsmWayId)
+				for j := 1; j <= restrictedPathLength-1; j++ {
+					next := path[i+j]
+					nextOsmWayId := g.GetOsmWayId(next)
+					subPath = append(subPath, nextOsmWayId)
+				}
+			} else {
+				from := path[i]
+				viaNode := g.GetHeadOfOutEdge(from)
+				to := path[i+1]
+
+				fromWayId := g.GetOsmWayId(from)
+				viaOsmNodeId := int64(g.GetVertexOsmId(viaNode))
+				toWayId := g.GetOsmWayId(to)
+				subPath = append(subPath, fromWayId)
+				subPath = append(subPath, viaOsmNodeId)
+				subPath = append(subPath, toWayId)
+			}
+			if isSame(subPath, restrictedPath) {
+				return subPath, false
+			}
+		}
+
+		return []int64{0}, true
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			rtree := spatialindex.NewRtree()
+
+			rtree.Build(re.GetGraph(), logger)
+
+			routingService, err := usecases.NewRoutingService(logger, re, rtree, altSearch, 0.05, true)
+			if err != nil {
+				panic(err)
+			}
+
+			qOrigin := tc.queryOrigin
+			qDestination := tc.queryDestination
+			sp, tp := routingService.Snap(context.Background(), qOrigin.GetLat(), qOrigin.GetLon(), qDestination.GetLat(), qDestination.GetLon())
+			crpQuery := routing.NewCRPALTBidirectionalSearch(re, 1.0)
+
+			_, _, _, path, _ := crpQuery.ShortestPathSearch(sp, tp)
+			if subPath, correct := isCorrect(path, tc.turnRestriction); !correct {
+				t.Errorf("%s: expected not contain path %v, got contain the path", tc.name, subPath)
+			}
+
+			alts, _, _ := altSearch.FindAlternativeRoutes(sp, tp, 3)
+
+			for i := 0; i < len(alts); i++ {
+				altPath := alts[i].GetEdgeIdPath()
+				if subPath, correct := isCorrect(altPath, tc.turnRestriction); !correct {
+					t.Errorf("%s: expected not contain path %v, got contain the path, restriction: %v", tc.name, subPath, tc.turnRestriction.restriction)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Summary
 - adds support for Openstreetmap  multiple via-way turn restrictions  (tested).
   - only supports multiple via-way turn restrictions where each via-way has only 2 OSM junction nodes. for example: https://www.openstreetmap.org/relation/17842412 
   - added routing with OSM turn restrictions test
